### PR TITLE
Changes to compile under Rust 1.0.0-alpha, possibly introduce life-destroying bugs.

### DIFF
--- a/src/demo/main.rs
+++ b/src/demo/main.rs
@@ -1,6 +1,5 @@
 #![crate_type = "bin"]
 
-#![feature(macro_rules)]
 extern crate sdl2;
 extern crate sdl2_ttf;
 
@@ -10,7 +9,7 @@ mod video;
 
 fn main() {
     let args = os::args();
-    println!("linked sdl2_ttf: {}", sdl2_ttf::get_linked_version());
+    println!("linked sdl2_ttf: {:?}", sdl2_ttf::get_linked_version());
     if args.len() < 2 {
         println!("Usage: ./demo font.[ttf|ttc|fon]")
     } else {

--- a/src/demo/video.rs
+++ b/src/demo/video.rs
@@ -1,20 +1,20 @@
 use sdl2;
 use sdl2_ttf;
 
-static SCREEN_WIDTH : int = 800;
-static SCREEN_HEIGHT : int = 600;
+static SCREEN_WIDTH : isize = 800;
+static SCREEN_HEIGHT : isize = 600;
 
 // fail when error
 macro_rules! trying(
     ($e:expr) => (match $e { Ok(e) => e, Err(e) => panic!("failed: {}", e) })
-)
+);
 
 // hadle the annoying Rect i32
 macro_rules! rect(
     ($x:expr, $y:expr, $w:expr, $h:expr) => (
         sdl2::rect::Rect::new($x as i32, $y as i32, $w as i32, $h as i32)
     )
-)
+);
 
 pub fn main(filename: &Path) {
     sdl2::init(sdl2::INIT_VIDEO);

--- a/src/sdl2_ttf/lib.rs
+++ b/src/sdl2_ttf/lib.rs
@@ -2,8 +2,6 @@
 A binding for SDL2_ttf.
  */
 
-#![feature(macro_rules)]
-
 #![crate_type = "lib"]
 #![desc = "SDL2_ttf bindings and wrappers"]
 #![comment = "SDL2_ttf bindings and wrappers"]
@@ -13,7 +11,7 @@ extern crate libc;
 extern crate sdl2;
 
 use libc::{c_int, c_long};
-use std::c_str::CString;
+use std::ffi::{c_str_to_bytes, CString};
 use std::num::FromPrimitive;
 use sdl2::surface::Surface;
 use sdl2::get_error;
@@ -60,24 +58,24 @@ bitflags!(flags FontStyle : c_int {
     const StyleItalic = ffi::TTF_STYLE_ITALIC,
     const StyleUnderline = ffi::TTF_STYLE_UNDERLINE,
     const StyleStrikeThrough = ffi::TTF_STYLE_STRIKETHROUGH
-})
+});
 
-#[deriving(Show, PartialEq, FromPrimitive)]
+#[derive(Show, PartialEq, FromPrimitive)]
 pub enum Hinting {
-    HintingNormal = ffi::TTF_HINTING_NORMAL as int,
-    HintingLight  = ffi::TTF_HINTING_LIGHT  as int,
-    HintingMono   = ffi::TTF_HINTING_MONO   as int,
-    HintingNone   = ffi::TTF_HINTING_NONE   as int
+    HintingNormal = ffi::TTF_HINTING_NORMAL as isize,
+    HintingLight  = ffi::TTF_HINTING_LIGHT  as isize,
+    HintingMono   = ffi::TTF_HINTING_MONO   as isize,
+    HintingNone   = ffi::TTF_HINTING_NONE   as isize
 }
 
 /// Glyph Metrics
-#[deriving(PartialEq, Clone, Show)]
+#[derive(PartialEq, Clone, Show)]
 pub struct GlyphMetrics {
-    pub minx: int,
-    pub maxx: int,
-    pub miny: int,
-    pub maxy: int,
-    pub advance: int
+    pub minx: isize,
+    pub maxx: isize,
+    pub miny: isize,
+    pub maxy: isize,
+    pub advance: isize
 }
 
 /// Returns the version of the dynamically linked SDL_ttf library
@@ -112,7 +110,7 @@ pub fn quit() {
 
 /// The opaque holder of a loaded font.
 #[allow(raw_pointer_deriving)]
-#[deriving(PartialEq)]
+#[derive(PartialEq)]
 pub struct Font {
     raw: *const ffi::TTF_Font,
     owned: bool
@@ -136,10 +134,11 @@ impl Font {
         Font { raw: raw, owned: owned }
     }
 
-    pub fn from_file(filename: &Path, ptsize: int) -> SdlResult<Font> {
+    pub fn from_file(filename: &Path, ptsize: isize) -> SdlResult<Font> {
         //! Load file for use as a font, at ptsize size.
         unsafe {
-            let raw = ffi::TTF_OpenFont(filename.to_c_str().unwrap(), ptsize as c_int);
+            let cstring = CString::from_slice(filename.as_str().unwrap().as_bytes());
+            let raw = ffi::TTF_OpenFont(cstring.as_ptr(), ptsize as c_int);
             if raw.is_null() {
                 Err(get_error())
             } else {
@@ -148,10 +147,11 @@ impl Font {
         }
     }
 
-    pub fn from_file_index(filename: &Path, ptsize: int, index: int) -> SdlResult<Font> {
+    pub fn from_file_index(filename: &Path, ptsize: isize, index: isize) -> SdlResult<Font> {
         //! Load file, face index, for use as a font, at ptsize size.
         unsafe {
-            let raw = ffi::TTF_OpenFontIndex(filename.to_c_str().unwrap(), ptsize as c_int, index as c_long);
+            let cstring = CString::from_slice(filename.as_str().unwrap().as_bytes());
+            let raw = ffi::TTF_OpenFontIndex(cstring.as_ptr(), ptsize as c_int, index as c_long);
             if raw.is_null() {
                 Err(get_error())
             } else {
@@ -175,14 +175,14 @@ impl Font {
         }
     }
 
-    pub fn get_outline(&self) -> int {
+    pub fn get_outline(&self) -> isize {
         //! Get font outline width.
         unsafe {
-            ffi::TTF_GetFontOutline(self.raw) as int
+            ffi::TTF_GetFontOutline(self.raw) as isize
         }
     }
 
-    pub fn set_outline(&mut self, outline: int) {
+    pub fn set_outline(&mut self, outline: isize) {
         //! Set font outline width.
         unsafe {
             ffi::TTF_SetFontOutline(self.raw, outline as c_int)
@@ -217,38 +217,38 @@ impl Font {
         }
     }
 
-    pub fn height(&self) -> int {
+    pub fn height(&self) -> isize {
         //! Get font maximum total height.
         unsafe {
-            ffi::TTF_FontHeight(self.raw) as int
+            ffi::TTF_FontHeight(self.raw) as isize
         }
     }
 
-    pub fn ascent(&self) -> int {
+    pub fn ascent(&self) -> isize {
         //! Get font highest ascent (height above base).
         unsafe {
-            ffi::TTF_FontAscent(self.raw) as int
+            ffi::TTF_FontAscent(self.raw) as isize
         }
     }
 
-    pub fn descent(&self) -> int {
+    pub fn descent(&self) -> isize {
         //! Get font lowest descent (height below base).
         unsafe {
-            ffi::TTF_FontDescent(self.raw) as int
+            ffi::TTF_FontDescent(self.raw) as isize
         }
     }
 
-    pub fn line_skip(&self) -> int {
+    pub fn line_skip(&self) -> isize {
         //! Get font recommended line spacing.
         unsafe {
-            ffi::TTF_FontLineSkip(self.raw) as int
+            ffi::TTF_FontLineSkip(self.raw) as isize
         }
     }
 
-    pub fn faces(&self) -> int {
+    pub fn faces(&self) -> isize {
         //! Get the number of faces in a font.
         unsafe {
-            ffi::TTF_FontFaces(self.raw) as int
+            ffi::TTF_FontFaces(self.raw) as isize
         }
     }
 
@@ -267,7 +267,7 @@ impl Font {
             if cname.is_null() {
                 None
             } else {
-                Some(CString::new(cname, false).as_str().unwrap().into_string())
+                Some(String::from_utf8_lossy(c_str_to_bytes(&cname)).to_string())
             }
         }
     }
@@ -279,19 +279,19 @@ impl Font {
             if cname.is_null() {
                 None
             } else {
-                Some(CString::new(cname, false).as_str().unwrap().into_string())
+                Some(String::from_utf8_lossy(c_str_to_bytes(&cname)).to_string())
             }
         }
     }
 
-    pub fn index_of_char(&self, ch: char) -> Option<uint> {
+    pub fn index_of_char(&self, ch: char) -> Option<usize> {
         //! Get individual font glyph availability.
         unsafe {
             let ret = ffi::TTF_GlyphIsProvided(self.raw, ch as u16);
             if ret == 0 {
                 None
             } else {
-                Some(ret as uint)
+                Some(ret as usize)
             }
         }
     }
@@ -310,50 +310,47 @@ impl Font {
         if ret != 0 {
             None
         } else {
-            Some(GlyphMetrics { minx: minx as int, maxx: maxx as int,
-                                miny: miny as int, maxy: maxy as int,
-                                advance: advance as int })
+            Some(GlyphMetrics { minx: minx as isize, maxx: maxx as isize,
+                                miny: miny as isize, maxy: maxy as isize,
+                                advance: advance as isize })
         }
     }
 
-    pub fn size_of_bytes(&self, text: &[u8]) -> SdlResult<(int, int)> {
+    pub fn size_of_bytes(&self, text: &str) -> SdlResult<(isize, isize)> {
         //! Get size of LATIN1 text string as would be rendered.
         let w = 0;
         let h = 0;
         let ret = unsafe {
-            text.with_c_str(|ctext| {
-                    ffi::TTF_SizeText(self.raw, ctext, &w, &h)
-                })
+            let ctext = CString::from_slice(text.as_bytes());
+            ffi::TTF_SizeText(self.raw, ctext.as_ptr(), &w, &h)
         };
         if ret != 0 {
             Err(get_error())
         } else {
-            Ok((w as int, h as int))
+            Ok((w as isize, h as isize))
         }
     }
 
-    pub fn size_of_str(&self, text: &str) -> SdlResult<(int, int)> {
+    pub fn size_of_str(&self, text: &str) -> SdlResult<(isize, isize)> {
         //! Get size of UTF8 text string as would be rendered.
         let w = 0;
         let h = 0;
         let ret = unsafe {
-            text.with_c_str(|ctext| {
-                    ffi::TTF_SizeUTF8(self.raw, ctext, &w, &h)
-                })
+            let ctext = CString::from_slice(text.as_bytes());
+            ffi::TTF_SizeUTF8(self.raw, ctext.as_ptr(), &w, &h)
         };
         if ret != 0 {
             Err(get_error())
         } else {
-            Ok((w as int, h as int))
+            Ok((w as isize, h as isize))
         }
     }
 
-    pub fn render_bytes_solid(&self, text: &[u8], fg: Color) -> SdlResult<Surface> {
+    pub fn render_bytes_solid(&self, text: &str, fg: Color) -> SdlResult<Surface> {
         //! Draw LATIN1 text in solid mode.
         unsafe {
-            let raw = text.with_c_str(|ctext| {
-                    ffi::TTF_RenderText_Solid(self.raw, ctext, color_to_c_color(fg))
-                });
+            let ctext = CString::from_slice(text.as_bytes());
+            let raw = ffi::TTF_RenderText_Solid(self.raw, ctext.as_ptr(), color_to_c_color(fg));
             if raw.is_null() {
                 Err(get_error())
             } else {
@@ -365,9 +362,8 @@ impl Font {
     pub fn render_str_solid(&self, text: &str, fg: Color) -> SdlResult<Surface> {
         //! Draw UTF8 text in solid mode.
         unsafe {
-            let raw = text.with_c_str(|ctext| {
-                    ffi::TTF_RenderUTF8_Solid(self.raw, ctext, color_to_c_color(fg))
-                });
+            let ctext = CString::from_slice(text.as_bytes());
+            let raw = ffi::TTF_RenderUTF8_Solid(self.raw, ctext.as_ptr(), color_to_c_color(fg));
             if raw.is_null() {
                 Err(get_error())
             } else {
@@ -388,12 +384,11 @@ impl Font {
         }
     }
 
-    pub fn render_bytes_shaded(&self, text: &[u8], fg: Color, bg: Color) -> SdlResult<Surface> {
+    pub fn render_bytes_shaded(&self, text: &str, fg: Color, bg: Color) -> SdlResult<Surface> {
         //! Draw LATIN1 text in shaded mode.
         unsafe {
-            let raw = text.with_c_str(|ctext| {
-                    ffi::TTF_RenderText_Shaded(self.raw, ctext, color_to_c_color(fg), color_to_c_color(bg))
-                });
+            let ctext = CString::from_slice(text.as_bytes());
+            let raw = ffi::TTF_RenderText_Shaded(self.raw, ctext.as_ptr(), color_to_c_color(fg), color_to_c_color(bg));
             if raw.is_null() {
                 Err(get_error())
             } else {
@@ -405,9 +400,8 @@ impl Font {
     pub fn render_str_shaded(&self, text: &str, fg: Color, bg: Color) -> SdlResult<Surface> {
         //! Draw UTF8 text in shaded mode.
         unsafe {
-            let raw = text.with_c_str(|ctext| {
-                    ffi::TTF_RenderUTF8_Shaded(self.raw, ctext, color_to_c_color(fg), color_to_c_color(bg))
-                });
+            let ctext = CString::from_slice(text.as_bytes());
+            let raw = ffi::TTF_RenderUTF8_Shaded(self.raw, ctext.as_ptr(), color_to_c_color(fg), color_to_c_color(bg));
             if raw.is_null() {
                 Err(get_error())
             } else {
@@ -428,12 +422,11 @@ impl Font {
         }
     }
 
-    pub fn render_bytes_blended(&self, text: &[u8], fg: Color) -> SdlResult<Surface> {
+    pub fn render_bytes_blended(&self, text: &str, fg: Color) -> SdlResult<Surface> {
         //! Draw LATIN1 text in blended mode.
         unsafe {
-            let raw = text.with_c_str(|ctext| {
-                    ffi::TTF_RenderText_Blended(self.raw, ctext, color_to_c_color(fg))
-                });
+            let ctext = CString::from_slice(text.as_bytes());
+            let raw = ffi::TTF_RenderText_Blended(self.raw, ctext.as_ptr(), color_to_c_color(fg));
             if raw.is_null() {
                 Err(get_error())
             } else {
@@ -445,9 +438,8 @@ impl Font {
     pub fn render_str_blended(&self, text: &str, fg: Color) -> SdlResult<Surface> {
         //! Draw UTF8 text in blended mode.
         unsafe {
-            let raw = text.with_c_str(|ctext| {
-                    ffi::TTF_RenderUTF8_Blended(self.raw, ctext, color_to_c_color(fg))
-                });
+            let ctext = CString::from_slice(text.as_bytes());
+            let raw = ffi::TTF_RenderUTF8_Blended(self.raw, ctext.as_ptr(), color_to_c_color(fg));
             if raw.is_null() {
                 Err(get_error())
             } else {
@@ -473,13 +465,13 @@ impl Font {
 /// Loader trait for RWops
 pub trait LoaderRWops {
     /// Load src for use as a font.
-    fn load_font(&self, ptsize: int) -> SdlResult<Font>;
+    fn load_font(&self, ptsize: isize) -> SdlResult<Font>;
     /// Load src for use as a font.
-    fn load_font_index(&self, ptsize: int, index: int) -> SdlResult<Font>;
+    fn load_font_index(&self, ptsize: isize, index: isize) -> SdlResult<Font>;
 }
 
 impl LoaderRWops for RWops {
-    fn load_font(&self, ptsize: int) -> SdlResult<Font> {
+    fn load_font(&self, ptsize: isize) -> SdlResult<Font> {
         let raw = unsafe {
             ffi::TTF_OpenFontRW(self.raw(), 0, ptsize as c_int)
         };
@@ -489,7 +481,7 @@ impl LoaderRWops for RWops {
             Ok(Font::from_ll(raw, true))
         }
     }
-    fn load_font_index(&self, ptsize: int, index: int) -> SdlResult<Font> {
+    fn load_font_index(&self, ptsize: isize, index: isize) -> SdlResult<Font> {
         let raw = unsafe {
             ffi::TTF_OpenFontIndexRW(self.raw(), 0, ptsize as c_int, index as c_long)
         };

--- a/src/sdl2_ttf/lib.rs
+++ b/src/sdl2_ttf/lib.rs
@@ -316,13 +316,13 @@ impl Font {
         }
     }
 
-    pub fn size_of_bytes(&self, text: &str) -> SdlResult<(isize, isize)> {
+    pub fn size_of_bytes(&self, text: &[u8]) -> SdlResult<(isize, isize)> {
         //! Get size of LATIN1 text string as would be rendered.
         let w = 0;
         let h = 0;
         let ret = unsafe {
-            let ctext = CString::from_slice(text.as_bytes());
-            ffi::TTF_SizeText(self.raw, ctext.as_ptr(), &w, &h)
+            let ctext = CString::from_slice(text).as_ptr();
+            ffi::TTF_SizeText(self.raw, ctext, &w, &h)
         };
         if ret != 0 {
             Err(get_error())
@@ -346,11 +346,11 @@ impl Font {
         }
     }
 
-    pub fn render_bytes_solid(&self, text: &str, fg: Color) -> SdlResult<Surface> {
+    pub fn render_bytes_solid(&self, text: &[u8], fg: Color) -> SdlResult<Surface> {
         //! Draw LATIN1 text in solid mode.
         unsafe {
-            let ctext = CString::from_slice(text.as_bytes());
-            let raw = ffi::TTF_RenderText_Solid(self.raw, ctext.as_ptr(), color_to_c_color(fg));
+            let ctext = CString::from_slice(text).as_ptr();
+            let raw = ffi::TTF_RenderText_Solid(self.raw, ctext, color_to_c_color(fg));
             if raw.is_null() {
                 Err(get_error())
             } else {
@@ -384,11 +384,11 @@ impl Font {
         }
     }
 
-    pub fn render_bytes_shaded(&self, text: &str, fg: Color, bg: Color) -> SdlResult<Surface> {
+    pub fn render_bytes_shaded(&self, text: &[u8], fg: Color, bg: Color) -> SdlResult<Surface> {
         //! Draw LATIN1 text in shaded mode.
         unsafe {
-            let ctext = CString::from_slice(text.as_bytes());
-            let raw = ffi::TTF_RenderText_Shaded(self.raw, ctext.as_ptr(), color_to_c_color(fg), color_to_c_color(bg));
+            let ctext = CString::from_slice(text).as_ptr();
+            let raw = ffi::TTF_RenderText_Shaded(self.raw, ctext, color_to_c_color(fg), color_to_c_color(bg));
             if raw.is_null() {
                 Err(get_error())
             } else {
@@ -422,11 +422,11 @@ impl Font {
         }
     }
 
-    pub fn render_bytes_blended(&self, text: &str, fg: Color) -> SdlResult<Surface> {
+    pub fn render_bytes_blended(&self, text: &[u8], fg: Color) -> SdlResult<Surface> {
         //! Draw LATIN1 text in blended mode.
         unsafe {
-            let ctext = CString::from_slice(text.as_bytes());
-            let raw = ffi::TTF_RenderText_Blended(self.raw, ctext.as_ptr(), color_to_c_color(fg));
+            let ctext = CString::from_slice(text).as_ptr();
+            let raw = ffi::TTF_RenderText_Blended(self.raw, ctext, color_to_c_color(fg));
             if raw.is_null() {
                 Err(get_error())
             } else {


### PR DESCRIPTION
I took a stab at upgrading this to be compatible with Rust 1.0 alpha. It now compiles on my machine correctly and the example app runs properly. I'm running the 1.0.0-alpha build and have not tried it on a nightly! There are still many warnings about unstable code.

I should stress that **I have no idea what I'm doing**. I'm very new to Rust and I know nothing about C. This is very much a case of me copying what other people have done without fully understanding the changes that I'm making. A lot of it came from https://github.com/AngryLawyer/rust-sdl2/pull/272, which upgraded that library.

One big issue (I think?) is the change I made to turn all `&[u8]` instances to `&str`. I really doubt that's the right thing to do, but I couldn't figure it out. Everything compiles and runs, but who knows what awful bugs I've introduced.

This gets me up and running, and hopefully it's a start for somebody else who does understand this to upgrade the library properly. Thanks!