### PR TITLE
Fix deprecation warnings/errors for 1.0-alpha2.

### DIFF
--- a/src/sdl2_ttf/lib.rs
+++ b/src/sdl2_ttf/lib.rs
@@ -3,9 +3,6 @@ A binding for SDL2_ttf.
  */
 
 #![crate_type = "lib"]
-#![desc = "SDL2_ttf bindings and wrappers"]
-#![comment = "SDL2_ttf bindings and wrappers"]
-#![license = "MIT"]
 
 extern crate libc;
 extern crate sdl2;
@@ -66,7 +63,7 @@ bitflags! {
     }
 }
 
-#[derive(Show, PartialEq, FromPrimitive)]
+#[derive(Debug, PartialEq, FromPrimitive)]
 pub enum Hinting {
     HintingNormal = ffi::TTF_HINTING_NORMAL as isize,
     HintingLight  = ffi::TTF_HINTING_LIGHT  as isize,
@@ -75,7 +72,7 @@ pub enum Hinting {
 }
 
 /// Glyph Metrics
-#[derive(PartialEq, Clone, Show)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct GlyphMetrics {
     pub minx: isize,
     pub maxx: isize,


### PR DESCRIPTION
This fixes a couple of deprecation warnings and a couple of errors. Everything in those deleted lines was already present in the `Cargo.toml`, which is what my limited Google research suggested is their replacement.

If you've updated `rust-sdl2` recently, #10 needs to be applied as well before this will compile.