### PR TITLE
 Depend on crates.io published version, update README, bump version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sdl2_ttf"
 description = "SDL2_ttf bindings for Rust"
 repository = "https://github.com/andelf/rust-sdl2_ttf"
-version = "0.0.3"
+version = "0.0.31"
 license = "MIT"
 readme = "README.md"
 authors = ["ShuYu Wang <andelf@gmail.com>"]
@@ -14,12 +14,14 @@ path = "src/sdl2_ttf/lib.rs"
 
 [dependencies]
 bitflags = "0.1"
+sdl2 = "0.0.31"
+sdl2-sys = "0.0.31"
 
-[dependencies.sdl2]
-git = "https://github.com/AngryLawyer/rust-sdl2/"
+# [dependencies.sdl2]
+# git = "https://github.com/AngryLawyer/rust-sdl2/"
 
-[dependencies.sdl2-sys]
-git = "https://github.com/AngryLawyer/rust-sdl2/"
+# [dependencies.sdl2-sys]
+# git = "https://github.com/AngryLawyer/rust-sdl2/"
 
 [[bin]]
 name = "demo"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Or, to depend on the newest rust-sdl2_ttf, reference the repository:
 
 ```toml
 [dependencies.sdl2_ttf]
-git = "https://github.com/andelf/rust-sdl2-ttf"
+git = "https://github.com/andelf/rust-sdl2_ttf"
 ```
 
 You can also just clone and build the library yourself:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Rust-SDL2_ttf
 
 [![Build Status](https://travis-ci.org/andelf/rust-sdl2_ttf.svg?branch=master)](https://travis-ci.org/andelf/rust-sdl2_ttf)
 
+Rust bindings for SDL2_ttf.
+
 ## Overview
 
 Rust-SDL2_ttf is a library for talking to the new SDL2_ttf library from Rust.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,39 @@
 Rust-SDL2_ttf
-===============
+=============
 
 [![Build Status](https://travis-ci.org/andelf/rust-sdl2_ttf.svg?branch=master)](https://travis-ci.org/andelf/rust-sdl2_ttf)
 
-Rust bindings for SDL2_ttf.
+## Overview
 
-Requirements
-------------
+Rust-SDL2_ttf is a library for talking to the new SDL2_ttf library from Rust.
 
-* [Rust-sdl2](https://github.com/AngryLawyer/rust-sdl2)
-* sdl_ttf 2.0 development libraries
-* Rust master
+Rust-SDL2_ttf uses the MIT licence.
 
-Installation
-------------
+## Requirements
 
+* [Rust-SDL2](https://github.com/AngryLawyer/rust-sdl2)
+* SDL2_ttf development libraries
+* Rust master or nightly
+
+## Installation
+
+Place the following into your project's Cargo.toml file:
+
+```toml
+[dependencies]
+sdl2_ttf = "0.0.31" # Doesn't work yet, needs to be published.
 ```
-# compile your rust-sdl2 somewhere
+
+Or, to depend on the newest rust-sdl2_ttf, reference the repository:
+
+```toml
+[dependencies.sdl2_ttf]
+git = "https://github.com/andelf/rust-sdl2-ttf"
+```
+
+You can also just clone and build the library yourself:
+
+```bash
 git clone https://github.com/andelf/rust-sdl2_ttf
 cd rust-sdl2_ttf
 cargo build
@@ -24,24 +41,25 @@ cargo build
 rustc -L. --cfg mac_framework src/sdl2_ttf/lib.rs
 ```
 
-For cargo:
+If you're not using Cargo, you can compile the library manually:
 
-```
-[dependencies]
-sdl2_ttf = "$version-here$"
-```
-
-or
-
-```
-[dependencies.sdl2_ttf]
-git = "https://github.com/andelf/rust-sdl2_ttf"
+```bash
+git clone https://github.com/andelf/rust-sdl2_ttf
+cd rust-sdl2_ttf
+rustc src/sdl2_ttf/lib.rs
 ```
 
+## Demo
 
-Demo
-----
+A simple demo that prints out a string given a font is included:
 
+```bash
+cargo run path/to/font.(ttf|ttc|fon)
 ```
-cargo run font.[ttf|ttc|fon]
+
+Or:
+
+```bash
+rustc -L. src/demo/main.rs -o demo
+./demo path/to/font.(ttf|ttc|fon)
 ```


### PR DESCRIPTION
Same as for rust-sdl2_mixer.