### PR TITLE
Bump the version of SDL2 to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sdl2_ttf"
 description = "SDL2_ttf bindings for Rust"
 repository = "https://github.com/andelf/rust-sdl2_ttf"
-version = "0.6.1"
+version = "0.9.0"
 license = "MIT"
 readme = "README.md"
 authors = ["ShuYu Wang <andelf@gmail.com>"]
@@ -14,8 +14,8 @@ path = "src/sdl2_ttf/lib.rs"
 
 [dependencies]
 bitflags = "0.2"
-sdl2 = "0.8"
-sdl2-sys = "*"
+sdl2 = "0.9"
+sdl2-sys = "0.6"
 libc = "0.1"
 
 # [dependencies.sdl2]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Place the following into your project's Cargo.toml file:
 
 ```toml
 [dependencies]
-sdl2_ttf = "0.6.0"
+sdl2_ttf = "0.9"
 ```
 
 Or, to use the newest rust-sdl2_ttf, reference the repository:

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -14,12 +14,7 @@ use sdl2::pixels::Color;
 static SCREEN_WIDTH : u32 = 800;
 static SCREEN_HEIGHT : u32 = 600;
 
-// fail when error
-macro_rules! trying(
-    ($e:expr) => (match $e { Ok(e) => e, Err(e) => panic!("failed: {}", e) })
-);
-
-// hadle the annoying Rect i32
+// handle the annoying Rect i32
 macro_rules! rect(
     ($x:expr, $y:expr, $w:expr, $h:expr) => (
         Rect::new_unwrap($x as i32, $y as i32, $w as u32, $h as u32)
@@ -53,9 +48,9 @@ fn get_centered_rect(rect_width: u32, rect_height: u32, cons_width: u32, cons_he
 fn run(filename: &Path) {
     let sdl_context = sdl2::init().unwrap();
     let video_subsys = sdl_context.video().unwrap();
-    sdl2_ttf::init();
+    let ttf_context = sdl2_ttf::init();
 
-    let window = video_subsys.window("rust-sdl2 demo: Video", SCREEN_WIDTH, SCREEN_HEIGHT)
+    let window = video_subsys.window("SDL2_TTF Example", SCREEN_WIDTH, SCREEN_HEIGHT)
         .position_centered()
         .opengl()
         .build()
@@ -64,11 +59,12 @@ fn run(filename: &Path) {
     let mut renderer = window.renderer().build().unwrap();
 
     // Load a font
-    let font = trying!(sdl2_ttf::Font::from_file(filename, 128));
+    let font = sdl2_ttf::Font::from_file(filename, 128).unwrap();
 
     // render a surface, and convert it to a texture bound to the renderer
-    let surface = trying!(font.render_str_blended("Hello Rust!", Color::RGBA(255, 0, 0, 255)));
-    let mut texture = trying!(renderer.create_texture_from_surface(&surface));
+    let surface = font.render("Hello Rust!",
+        sdl2_ttf::blended(Color::RGBA(255, 0, 0, 255))).unwrap();
+    let mut texture = renderer.create_texture_from_surface(&surface).unwrap();
 
     renderer.set_draw_color(Color::RGBA(195, 217, 255, 255));
     renderer.clear();
@@ -91,8 +87,6 @@ fn run(filename: &Path) {
             }
         }
     }
-
-    sdl2_ttf::quit();
 }
 
 fn main() {

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -7,9 +7,12 @@ use std::path::Path;
 use sdl2::*;
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
+use sdl2::rect::Rect;
+use sdl2::render::TextureQuery;
+use sdl2::pixels::Color;
 
-static SCREEN_WIDTH : i32 = 800;
-static SCREEN_HEIGHT : i32 = 600;
+static SCREEN_WIDTH : u32 = 800;
+static SCREEN_HEIGHT : u32 = 600;
 
 // fail when error
 macro_rules! trying(
@@ -19,16 +22,40 @@ macro_rules! trying(
 // hadle the annoying Rect i32
 macro_rules! rect(
     ($x:expr, $y:expr, $w:expr, $h:expr) => (
-        sdl2::rect::Rect::new($x as i32, $y as i32, $w as u32, $h as u32)
+        Rect::new_unwrap($x as i32, $y as i32, $w as u32, $h as u32)
     )
 );
+
+// Scale fonts to a reasonable size when they're too big (though they might look less smooth)
+fn get_centered_rect(rect_width: u32, rect_height: u32, cons_width: u32, cons_height: u32) -> Rect {
+    let wr = rect_width as f32 / cons_width as f32;
+    let hr = rect_height as f32 / cons_height as f32;
+
+    let (w, h) = if wr > 1f32 || hr > 1f32 {
+        if wr > hr {
+            println!("Scaling down! The text will look worse!");
+            let h = (rect_height as f32 / wr) as i32;
+            (cons_width as i32, h)
+        } else {
+            println!("Scaling down! The text will look worse!");
+            let w = (rect_width as f32 / hr) as i32;
+            (w, cons_height as i32)
+        }
+    } else {
+        (rect_width as i32, rect_height as i32)
+    };
+
+    let cx = (SCREEN_WIDTH as i32 - w) / 2;
+    let cy = (SCREEN_HEIGHT as i32 - h) / 2;
+    rect!(cx, cy, w, h)
+}
 
 fn run(filename: &Path) {
     let sdl_context = sdl2::init().unwrap();
     let video_subsys = sdl_context.video().unwrap();
     sdl2_ttf::init();
 
-    let window = video_subsys.window("rust-sdl2 demo: Video", 800, 600)
+    let window = video_subsys.window("rust-sdl2 demo: Video", SCREEN_WIDTH, SCREEN_HEIGHT)
         .position_centered()
         .opengl()
         .build()
@@ -40,16 +67,19 @@ fn run(filename: &Path) {
     let font = trying!(sdl2_ttf::Font::from_file(filename, 128));
 
     // render a surface, and convert it to a texture bound to the renderer
-    let surface = trying!(font.render_str_blended("Hello Rust!", sdl2::pixels::Color::RGBA(255, 0, 0, 255)));
+    let surface = trying!(font.render_str_blended("Hello Rust!", Color::RGBA(255, 0, 0, 255)));
     let mut texture = trying!(renderer.create_texture_from_surface(&surface));
 
-    renderer.set_draw_color(sdl2::pixels::Color::RGBA(195, 217, 255, 255));
+    renderer.set_draw_color(Color::RGBA(195, 217, 255, 255));
     renderer.clear();
 
-    let (w, h) = { let q = texture.query(); (q.width, q.height) };
+    let TextureQuery { width, height, .. } = texture.query();
 
-    renderer.copy(&mut texture, None, Some(rect!((SCREEN_WIDTH as u32 - w)/ 2, (SCREEN_HEIGHT as u32 - h)/ 2, w, h)).unwrap().unwrap());
+    // If the example text is too big for the screen, downscale it (and center irregardless)
+    let padding = 64;
+    let target = get_centered_rect(width, height, SCREEN_WIDTH - padding, SCREEN_HEIGHT - padding);
 
+    renderer.copy(&mut texture, None, Some(target));
     renderer.present();
 
     'mainloop: loop {


### PR DESCRIPTION
To make the sdl2 data types match the current version.
I also fixed a bug in the demo where it would get an integer overflow when centering a font if the rendered surface was larger than the set screen (window) size.