### PR TITLE
Implement From<&String> for Text

### DIFF
--- a/src/sdl2_ttf/lib.rs
+++ b/src/sdl2_ttf/lib.rs
@@ -179,9 +179,16 @@ pub enum Text<'a> {
     Char(char),
 }
 
-/// Automatically convert strings to the right format
+/// Automatically convert strs to the right format
 impl <'a> From<&'a str> for Text<'a> {
     fn from(string: &'a str) -> Text<'a> {
+        Text::Utf8(string)
+    }
+}
+
+/// Automatically convert Strings to the right format
+impl <'a> From<&'a String> for Text<'a> {
+    fn from(string: &'a String) -> Text<'a> {
         Text::Utf8(string)
     }
 }


### PR DESCRIPTION
Before this pull request, code like this would not compile
```rust
let score = 30;
let score_str = "Score: ".to_string() + &score.to_string();
font.render(&score_str,sdl2_ttf::blended(sdl2::pixels::Color::RGBA(255, 0, 0, 255))).unwrap();
```
even though code like this would compile
```rust
let score = 30;
let score_str = "Score: ".to_string() + &score.to_string();
let score_txt = sdl2_ttf::Text::Utf8(&score_str);
font.render(score_txt,sdl2_ttf::blended(sdl2::pixels::Color::RGBA(255, 0, 0, 255))).unwrap();
```

This pull request fixes that by letting both of them compile.

There might be a deeper issue in rust because the error in the first code example I wrote says that the From trait is not implemented for <&collections::string::String>, even though [the book](https://doc.rust-lang.org/stable/book/strings.html) says that adding a & should coerce the strings into str, although I don't know enough to really look into that and besides, this patch fixed the issue for me.