### PR TITLE
Updated dependencies; changed load_from_rwops font signature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sdl2_ttf"
 description = "SDL2_ttf bindings for Rust"
 repository = "https://github.com/andelf/rust-sdl2_ttf"
-version = "0.19.0"
+version = "0.21.0"
 license = "MIT"
 readme = "README.md"
 authors = ["ShuYu Wang <andelf@gmail.com>"]
@@ -14,8 +14,8 @@ path = "src/sdl2_ttf/lib.rs"
 
 [dependencies]
 bitflags = "0.5"
-sdl2 = "0.20"
-sdl2-sys = "0.19.0"
+sdl2 = "0.21"
+sdl2-sys = "0.21"
 
 # [dependencies.sdl2]
 # git = "https://github.com/AngryLawyer/rust-sdl2/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "sdl2_ttf"
 path = "src/sdl2_ttf/lib.rs"
 
 [dependencies]
-bitflags = "0.5"
+bitflags = "0.6"
 sdl2 = "0.21"
 sdl2-sys = "0.21"
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Place the following into your project's Cargo.toml file:
 
 ```toml
 [dependencies]
-sdl2_ttf = "0.16"
+sdl2_ttf = "0.21"
 ```
 
 sdl2_ttf is directly compatible with the corresponding version of sdl2.

--- a/src/sdl2_ttf/context.rs
+++ b/src/sdl2_ttf/context.rs
@@ -42,7 +42,7 @@ impl Sdl2TtfContext {
 
     /// Loads a font from the given SDL2 rwops object with the given size in
     /// points.
-    pub fn load_font_from_rwops(&self, rwops: &RWops, point_size: u16)
+    pub fn load_font_from_rwops(&self, rwops: &mut RWops, point_size: u16)
             -> Result<Font, String> {
         let raw = unsafe {
             ffi::TTF_OpenFontRW(rwops.raw(), 0, point_size as c_int)
@@ -56,7 +56,7 @@ impl Sdl2TtfContext {
 
     /// Loads the font at the given index of the SDL2 rwops object with
     /// the given size in points.
-    pub fn load_font_at_index_from_rwops(&self, rwops: &RWops, index: u32,
+    pub fn load_font_at_index_from_rwops(&self, rwops: &mut RWops, index: u32,
             point_size: u16) -> Result<Font, String> {
         let raw = unsafe {
             ffi::TTF_OpenFontIndexRW(rwops.raw(), 0, point_size as c_int,


### PR DESCRIPTION
Bumped sdl_ttf version to 0.21

* Updated bitflags to 0.6, sdl to 0.21 and sdl-sys to 0.21
* Also changed load_from_rwops signature, see [#29](https://github.com/andelf/rust-sdl2_ttf/issues/29#issuecomment-232339516)

I guess an update to crates.io is also necessary.