### PR TITLE
Exported sdl_ttf::context::InitError

### DIFF
--- a/src/sdl2_ttf/lib.rs
+++ b/src/sdl2_ttf/lib.rs
@@ -32,7 +32,7 @@ mod others {
 }
 
 pub use context::{
-    init, has_been_initialized, get_linked_version, Sdl2TtfContext
+    init, has_been_initialized, get_linked_version, Sdl2TtfContext, InitError,
 };
 pub use font::{
     Font, FontStyle, Hinting, GlyphMetrics, PartialRendering, FontError,


### PR DESCRIPTION
Because otherwise you can't actually *handle* an InitError since you can't specify a function that takes it as an argument type.

For instance, you can't write:
```.rust
impl From<sdl2_ttf::context::InitError> for MyGameError {
    fn from(e: sdl2_ttf::context::InitError) -> MyGameError {
        let msg = format!("SDL mixer init error: {}", e);
        MyGameError::SDLInitError(msg)
    }
}
```