### PR TITLE
Make Font never outlive its RWops anymore

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -75,7 +75,7 @@ fn run(font_path: &Path) {
     let padding = 64;
     let target = get_centered_rect(width, height, SCREEN_WIDTH - padding, SCREEN_HEIGHT - padding);
 
-    renderer.copy(&mut texture, None, Some(target));
+    renderer.copy(&mut texture, None, Some(target)).unwrap();
     renderer.present();
 
     'mainloop: loop {

--- a/src/sdl2_ttf/context.rs
+++ b/src/sdl2_ttf/context.rs
@@ -29,34 +29,34 @@ impl Drop for Sdl2TtfContext {
 
 impl Sdl2TtfContext {
     /// Loads a font from the given file with the given size in points.
-    pub fn load_font(&self, path: &Path, point_size: u16) -> Result<Font, String> {
+    pub fn load_font<'a>(&'a self, path: &'a Path, point_size: u16) -> Result<Font, String> {
         internal_load_font(path, point_size)
     }
 
     /// Loads the font at the given index of the file, with the given
     /// size in points.
-    pub fn load_font_at_index(&self, path: &Path, index: u32, point_size: u16)
+    pub fn load_font_at_index<'a>(&'a self, path: &'a Path, index: u32, point_size: u16)
             -> Result<Font, String> {
         internal_load_font_at_index(path, index, point_size)
     }
 
     /// Loads a font from the given SDL2 rwops object with the given size in
     /// points.
-    pub fn load_font_from_rwops(&self, rwops: &mut RWops, point_size: u16)
-            -> Result<Font, String> {
+    pub fn load_font_from_rwops<'a>(&'a self, rwops: RWops<'a>, point_size: u16)
+            -> Result<Font<'a>, String> {
         let raw = unsafe {
             ffi::TTF_OpenFontRW(rwops.raw(), 0, point_size as c_int)
         };
         if (raw as *mut ()).is_null() {
             Err(get_error())
         } else {
-            Ok(internal_load_font_from_ll(raw, true))
+            Ok(internal_load_font_from_ll(raw, Some(rwops)))
         }
     }
 
     /// Loads the font at the given index of the SDL2 rwops object with
     /// the given size in points.
-    pub fn load_font_at_index_from_rwops(&self, rwops: &mut RWops, index: u32,
+    pub fn load_font_at_index_from_rwops<'a>(&'a self, rwops: RWops<'a>, index: u32,
             point_size: u16) -> Result<Font, String> {
         let raw = unsafe {
             ffi::TTF_OpenFontIndexRW(rwops.raw(), 0, point_size as c_int,
@@ -65,7 +65,7 @@ impl Sdl2TtfContext {
         if (raw as *mut ()).is_null() {
             Err(get_error())
         } else {
-            Ok(internal_load_font_from_ll(raw, true))
+            Ok(internal_load_font_from_ll(raw, Some(rwops)))
         }
     }
 }


### PR DESCRIPTION
* Closes #43
* Closes #29

The example linked works as usual, but I'd like to know if this fix fixes the various segfaults that happened because of it.

cc @icefoxen for testing, since you had a 100% sure way to test that.

This change breaks the API, so a version bump will be needed.