### PR TITLE
Fix lifetime error in load_font

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sdl2_ttf"
 description = "SDL2_ttf bindings for Rust"
 repository = "https://github.com/andelf/rust-sdl2_ttf"
-version = "0.25.0"
+version = "0.25.1"
 license = "MIT"
 readme = "README.md"
 authors = ["ShuYu Wang <andelf@gmail.com>"]

--- a/src/sdl2_ttf/context.rs
+++ b/src/sdl2_ttf/context.rs
@@ -42,8 +42,8 @@ impl Sdl2TtfContext {
 
     /// Loads a font from the given SDL2 rwops object with the given size in
     /// points.
-    pub fn load_font_from_rwops<'a>(&'a self, rwops: RWops<'a>, point_size: u16)
-            -> Result<Font<'a>, String> {
+    pub fn load_font_from_rwops<'a,'b>(&'a self, rwops: RWops<'b>, point_size: u16)
+            -> Result<Font<'b>, String> {
         let raw = unsafe {
             ffi::TTF_OpenFontRW(rwops.raw(), 0, point_size as c_int)
         };
@@ -56,8 +56,8 @@ impl Sdl2TtfContext {
 
     /// Loads the font at the given index of the SDL2 rwops object with
     /// the given size in points.
-    pub fn load_font_at_index_from_rwops<'a>(&'a self, rwops: RWops<'a>, index: u32,
-            point_size: u16) -> Result<Font, String> {
+    pub fn load_font_at_index_from_rwops<'a,'b>(&'a self, rwops: RWops<'b>, index: u32,
+            point_size: u16) -> Result<Font<'b>, String> {
         let raw = unsafe {
             ffi::TTF_OpenFontIndexRW(rwops.raw(), 0, point_size as c_int,
                 index as c_long)


### PR DESCRIPTION
Basically my PR (#45) had a major flaw : 

```rust
pub fn load_font_from_rwops<'a>(&'a self, rwops: RWops<'a>, point_size: u16)
```
basically meant that RWops had the same lifetime as `self` (which is `Sdl2TtfContext`), meaning that since the context was loaded dynamically, Rwops<'static> was never possible, meaning that loading from static_bytes was harder to do.

The correct way to do this is : 
```rust
pub fn load_font_from_rwops<'a,'b>(&'a self, rwops: RWops<'b>, point_size: u16)
```

This simple fix fixes that. I also bumped the crate minor version, cause I think this breaks the API.